### PR TITLE
DXIL.bt fix padding and some odd indentation

### DIFF
--- a/DXIL.bt
+++ b/DXIL.bt
@@ -41,6 +41,8 @@ struct DXBCChunkHeader
   char fourcc[4];
   uint32 dataLength;
 
+  local int64 dataStartFilePosition <hidden=true> = FTell();
+  
   if(fourcc[0] == 'I' && fourcc[1] == 'S' && fourcc[2] == 'G' && fourcc[3] == '1')
   {
     byte supported_data[dataLength];
@@ -85,205 +87,205 @@ struct DXBCChunkHeader
   }
   else if(fourcc[0] == 'P' && fourcc[1] == 'S' && fourcc[2] == 'V' && fourcc[3] == '0')
   {
-// all this from DxilPipelineStateValidation.h
+    // all this from DxilPipelineStateValidation.h
 
-struct VSInfo {
-  char OutputPositionPresent;
-};
-struct HSInfo {
-  uint32 InputControlPointCount;      // max control points == 32
-  uint32 OutputControlPointCount;     // max control points == 32
-  uint32 TessellatorDomain;           // hlsl::DXIL::TessellatorDomain/D3D11_SB_TESSELLATOR_DOMAIN
-  uint32 TessellatorOutputPrimitive;  // hlsl::DXIL::TessellatorOutputPrimitive/D3D11_SB_TESSELLATOR_OUTPUT_PRIMITIVE
-};
-struct DSInfo {
-  uint32 InputControlPointCount;      // max control points == 32
-  char OutputPositionPresent;
-  uint32 TessellatorDomain;           // hlsl::DXIL::TessellatorDomain/D3D11_SB_TESSELLATOR_DOMAIN
-};
-struct GSInfo {
-  uint32 InputPrimitive;              // hlsl::DXIL::InputPrimitive/D3D10_SB_PRIMITIVE
-  uint32 OutputTopology;              // hlsl::DXIL::PrimitiveTopology/D3D10_SB_PRIMITIVE_TOPOLOGY
-  uint32 OutputStreamMask;            // max streams == 4
-  char OutputPositionPresent;
-};
-struct PSInfo {
-  char DepthOutput;
-  char SampleFrequency;
-};
-struct MSInfo {
-  uint32 GroupSharedBytesUsed;
-  uint32 GroupSharedBytesDependentOnViewID;
-  uint32 PayloadSizeInBytes;
-  uint16 MaxOutputVertices;
-  uint16 MaxOutputPrimitives;
-};
-struct ASInfo {
-  uint32 PayloadSizeInBytes;
-};
-struct MSInfo1 {
-  unsigned char SigPrimVectors;     // Primitive output for MS
-  unsigned char MeshOutputTopology;
-};
+    struct VSInfo {
+      char OutputPositionPresent;
+    };
+    struct HSInfo {
+      uint32 InputControlPointCount;      // max control points == 32
+      uint32 OutputControlPointCount;     // max control points == 32
+      uint32 TessellatorDomain;           // hlsl::DXIL::TessellatorDomain/D3D11_SB_TESSELLATOR_DOMAIN
+      uint32 TessellatorOutputPrimitive;  // hlsl::DXIL::TessellatorOutputPrimitive/D3D11_SB_TESSELLATOR_OUTPUT_PRIMITIVE
+    };
+    struct DSInfo {
+      uint32 InputControlPointCount;      // max control points == 32
+      char OutputPositionPresent;
+      uint32 TessellatorDomain;           // hlsl::DXIL::TessellatorDomain/D3D11_SB_TESSELLATOR_DOMAIN
+    };
+    struct GSInfo {
+      uint32 InputPrimitive;              // hlsl::DXIL::InputPrimitive/D3D10_SB_PRIMITIVE
+      uint32 OutputTopology;              // hlsl::DXIL::PrimitiveTopology/D3D10_SB_PRIMITIVE_TOPOLOGY
+      uint32 OutputStreamMask;            // max streams == 4
+      char OutputPositionPresent;
+    };
+    struct PSInfo {
+      char DepthOutput;
+      char SampleFrequency;
+    };
+    struct MSInfo {
+      uint32 GroupSharedBytesUsed;
+      uint32 GroupSharedBytesDependentOnViewID;
+      uint32 PayloadSizeInBytes;
+      uint16 MaxOutputVertices;
+      uint16 MaxOutputPrimitives;
+    };
+    struct ASInfo {
+      uint32 PayloadSizeInBytes;
+    };
+    struct MSInfo1 {
+      unsigned char SigPrimVectors;     // Primitive output for MS
+      unsigned char MeshOutputTopology;
+    };
 
-// Versioning is additive and based on size
-struct PSVRuntimeInfo0
-{
-  union {
-    VSInfo VS;
-    HSInfo HS;
-    DSInfo DS;
-    GSInfo GS;
-    PSInfo PS;
-    MSInfo MS;
-    ASInfo AS;
-  } StageInfo;
-  uint32 MinimumExpectedWaveLaneCount;  // minimum lane count required, 0 if unused
-  uint32 MaximumExpectedWaveLaneCount;  // maximum lane count required, 0xffffffff if unused
-};
+    // Versioning is additive and based on size
+    struct PSVRuntimeInfo0
+    {
+      union {
+        VSInfo VS;
+        HSInfo HS;
+        DSInfo DS;
+        GSInfo GS;
+        PSInfo PS;
+        MSInfo MS;
+        ASInfo AS;
+      } StageInfo;
+      uint32 MinimumExpectedWaveLaneCount;  // minimum lane count required, 0 if unused
+      uint32 MaximumExpectedWaveLaneCount;  // maximum lane count required, 0xffffffff if unused
+    };
 
-enum <byte> PSVShaderKind
-{
-  Pixel = 0,
-  Vertex,
-  Geometry,
-  Hull,
-  Domain,
-  Compute,
-  Library,
-  RayGeneration,
-  Intersection,
-  AnyHit,
-  ClosestHit,
-  Miss,
-  Callable,
-  Mesh,
-  Amplification,
-  InvalidStage,
-};
+    enum <byte> PSVShaderKind
+    {
+      Pixel = 0,
+      Vertex,
+      Geometry,
+      Hull,
+      Domain,
+      Compute,
+      Library,
+      RayGeneration,
+      Intersection,
+      AnyHit,
+      ClosestHit,
+      Miss,
+      Callable,
+      Mesh,
+      Amplification,
+      InvalidStage,
+    };
 
-struct PSVRuntimeInfo1 // : public PSVRuntimeInfo0
-{
-  PSVRuntimeInfo0 parent;
-  PSVShaderKind ShaderStage;
-  byte UsesViewID;
-  union {
-    uint16 MaxVertexCount;          // MaxVertexCount for GS only (max 1024)
-    byte SigPatchConstOrPrimVectors;  // Output for HS; Input for DS; Primitive output for MS (overlaps MS1::SigPrimVectors)
-    MSInfo1 MS1;
-  } StageInfo1;
+    struct PSVRuntimeInfo1 // : public PSVRuntimeInfo0
+    {
+      PSVRuntimeInfo0 parent;
+      PSVShaderKind ShaderStage;
+      byte UsesViewID;
+      union {
+        uint16 MaxVertexCount;          // MaxVertexCount for GS only (max 1024)
+        byte SigPatchConstOrPrimVectors;  // Output for HS; Input for DS; Primitive output for MS (overlaps MS1::SigPrimVectors)
+        MSInfo1 MS1;
+      } StageInfo1;
+    
+      // PSVSignatureElement counts
+      byte SigInputElements;
+      byte SigOutputElements;
+      byte SigPatchConstOrPrimElements;
+    
+      // Number of packed vectors per signature
+      byte SigInputVectors;
+      byte SigOutputVectors[4];      // Array for GS Stream Out Index
+    };
 
-  // PSVSignatureElement counts
-  byte SigInputElements;
-  byte SigOutputElements;
-  byte SigPatchConstOrPrimElements;
+    enum <uint32> PSVResourceType
+    {
+      InvalidResource = 0,
+    
+      Sampler,
+      CBV,
+      SRVTyped,
+      SRVRaw,
+      SRVStructured,
+      UAVTyped,
+      UAVRaw,
+      UAVStructured,
+      UAVStructuredWithCounter
+    };
 
-  // Number of packed vectors per signature
-  byte SigInputVectors;
-  byte SigOutputVectors[4];      // Array for GS Stream Out Index
-};
+    struct PSVResourceBindInfo0
+    {
+      PSVResourceType ResType;
+      uint32 Space;
+      uint32 LowerBound;
+      uint32 UpperBound;
+    };
 
-enum <uint32> PSVResourceType
-{
-  InvalidResource = 0,
+    enum <byte> PSVSemanticKind
+    {
+      Arbitrary,
+      VertexID,
+      InstanceID,
+      Position,
+      RenderTargetArrayIndex,
+      ViewPortArrayIndex,
+      ClipDistance,
+      CullDistance,
+      OutputControlPointID,
+      DomainLocation,
+      PrimitiveID,
+      GSInstanceID,
+      SampleIndex,
+      IsFrontFace,
+      Coverage,
+      InnerCoverage,
+      Target,
+      Depth,
+      DepthLessEqual,
+      DepthGreaterEqual,
+      StencilRef,
+      DispatchThreadID,
+      GroupID,
+      GroupIndex,
+      GroupThreadID,
+      TessFactor,
+      InsideTessFactor,
+      ViewID,
+      Barycentrics,
+      InvalidSemantic,
+    };
 
-  Sampler,
-  CBV,
-  SRVTyped,
-  SRVRaw,
-  SRVStructured,
-  UAVTyped,
-  UAVRaw,
-  UAVStructured,
-  UAVStructuredWithCounter
-};
+    enum <byte> DxilProgramSigCompType
+    {
+      Unknown = 0,
+      UInt32 = 1,
+      SInt32 = 2,
+      Float32 = 3,
+      UInt16 = 4,
+      SInt16 = 5,
+      Float16 = 6,
+      UInt64 = 7,
+      SInt64 = 8,
+      Float64 = 9,
+    };
 
-struct PSVResourceBindInfo0
-{
-  PSVResourceType ResType;
-  uint32 Space;
-  uint32 LowerBound;
-  uint32 UpperBound;
-};
+    enum <byte> InterpolationMode
+    {
+      Undefined                   = 0,
+      Constant                    = 1,
+      Linear                      = 2,
+      LinearCentroid              = 3,
+      LinearNoperspective         = 4,
+      LinearNoperspectiveCentroid = 5,
+      LinearSample                = 6,
+      LinearNoperspectiveSample   = 7,
+      InvalidInterp               = 8
+    };
 
-enum <byte> PSVSemanticKind
-{
-  Arbitrary,
-  VertexID,
-  InstanceID,
-  Position,
-  RenderTargetArrayIndex,
-  ViewPortArrayIndex,
-  ClipDistance,
-  CullDistance,
-  OutputControlPointID,
-  DomainLocation,
-  PrimitiveID,
-  GSInstanceID,
-  SampleIndex,
-  IsFrontFace,
-  Coverage,
-  InnerCoverage,
-  Target,
-  Depth,
-  DepthLessEqual,
-  DepthGreaterEqual,
-  StencilRef,
-  DispatchThreadID,
-  GroupID,
-  GroupIndex,
-  GroupThreadID,
-  TessFactor,
-  InsideTessFactor,
-  ViewID,
-  Barycentrics,
-  InvalidSemantic,
-};
-
-enum <byte> DxilProgramSigCompType
-{
-  Unknown = 0,
-  UInt32 = 1,
-  SInt32 = 2,
-  Float32 = 3,
-  UInt16 = 4,
-  SInt16 = 5,
-  Float16 = 6,
-  UInt64 = 7,
-  SInt64 = 8,
-  Float64 = 9,
-};
-
-enum <byte> InterpolationMode
-{
-  Undefined                   = 0,
-  Constant                    = 1,
-  Linear                      = 2,
-  LinearCentroid              = 3,
-  LinearNoperspective         = 4,
-  LinearNoperspectiveCentroid = 5,
-  LinearSample                = 6,
-  LinearNoperspectiveSample   = 7,
-  InvalidInterp               = 8
-};
-
-struct PSVSignatureElement0
-{
-  uint32 SemanticName;          // Offset into StringTable
-  uint32 SemanticIndexes;       // Offset into PSVSemanticIndexTable, count == Rows
-  byte Rows;                   // Number of rows this element occupies
-  byte StartRow;               // Starting row of packing location if allocated
-  byte Cols : 4;
-  byte StartCol : 2;
-  byte Allocated : 2;          // 0:4 = Cols, 4:6 = StartCol, 6:7 == Allocated
-  PSVSemanticKind SemanticKind;
-  DxilProgramSigCompType ComponentType;
-  InterpolationMode InterpMode;
-  byte DynamicIndexMask : 4;
-  byte OutputStream : 2;   // 0:4 = DynamicIndexMask, 4:6 = OutputStream (0-3)
-  byte Unused : 2;
-  byte Reserved;
-};
+    struct PSVSignatureElement0
+    {
+      uint32 SemanticName;          // Offset into StringTable
+      uint32 SemanticIndexes;       // Offset into PSVSemanticIndexTable, count == Rows
+      byte Rows;                   // Number of rows this element occupies
+      byte StartRow;               // Starting row of packing location if allocated
+      byte Cols : 4;
+      byte StartCol : 2;
+      byte Allocated : 2;          // 0:4 = Cols, 4:6 = StartCol, 6:7 == Allocated
+      PSVSemanticKind SemanticKind;
+      DxilProgramSigCompType ComponentType;
+      InterpolationMode InterpMode;
+      byte DynamicIndexMask : 4;
+      byte OutputStream : 2;   // 0:4 = DynamicIndexMask, 4:6 = OutputStream (0-3)
+      byte Unused : 2;
+      byte Reserved;
+    };
 
     uint32 PSVRuntimeInfo_size;
     if(PSVRuntimeInfo_size == sizeof(PSVRuntimeInfo0))
@@ -294,10 +296,8 @@ struct PSVSignatureElement0
     {
       PSVRuntimeInfo1 runtimeInfo1;
     }
-    else
-    {
-      error;
-    }
+    // else padding will be displayed afterward for the remaining unknown content.
+
     uint32 ResourceCount;
     if(ResourceCount > 0)
     {
@@ -381,15 +381,23 @@ struct PSVSignatureElement0
     {
       char id0[2];
       byte id1[2] <format=hex>;
-BitfieldDisablePadding();
+      BitfieldDisablePadding();
       byte bitcode[BitcodeSize-4] <format=hex>;
-BitfieldEnablePadding();
+      BitfieldEnablePadding();
     } bitcode;
   }
   else
   {
     byte unknown_data[dataLength];
   }
+
+  // For any remaining content after the known portion of the chunk, display padding bytes
+  // so that later chunks align correctly.
+  local int64 paddingLength = dataLength - (FTell() - dataStartFilePosition);
+  if (paddingLength > 0)
+  {
+    byte padding[paddingLength];
+  }
 };
 
-DXBCChunkHeader chunks[header.numChunks] <optimize=false>; 
+DXBCChunkHeader chunks[header.numChunks] <optimize=false>;


### PR DESCRIPTION
The SFI0 chunk did not account for additional `dataLength` bytes after the known portion, causing misalignment of all later chunks; and PSV0 would throw an `error` rather than successfully display what it could, which caused any later known chunks to not be shown. You may want to enable "Hide whitespace" on the Files Changed tab to reduce the diff noise initially. Thank you for this template.